### PR TITLE
Merge RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#   ╔╦╗╦═╗╔═╗╦  ╦╦╔═╗ ┬ ┬┌┬┐┬                           #
+#    ║ ╠╦╝╠═╣╚╗╔╝║╚═╗ └┬┘││││                           #
+#  o ╩ ╩╚═╩ ╩ ╚╝ ╩╚═╝o ┴ ┴ ┴┴─┘                         #
+#                                                       #
+# This file configures Travis CI.                       #
+# (i.e. how we run the tests... mainly)                 #
+#                                                       #
+# https://docs.travis-ci.com/user/customizing-the-build #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+language: node_js
+
+node_js:
+  - "6"
+  - "8"
+  - "node"
+  
+services:
+  - mongodb

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-========================================
+## [<img title="skipper-gridfs - GridFS filesystem adapter for Skipper" src="http://i.imgur.com/P6gptnI.png" width="200px" alt="skipper emblem - face of a ship's captain"/>](https://github.com/dmedina2015/skipper-gridfs) GridFS Filesystem Adapter
 
-## DISCLAIMER
+[![npm version](https://badge.fury.io/js/%40dmedina2015%2Fskipper-gridfs.svg)](https://badge.fury.io/js/%40dmedina2015%2Fskipper-gridfs) &nbsp; 
+[![Build Status](https://travis-ci.com/dmedina2015/skipper-gridfs.svg?branch=master)](https://travis-ci.com/dmedina2015/skipper-gridfs)
+&nbsp;
 
-This is a fork package from skipper-gridfs. Below are the diferences from [original project](https://www.npmjs.com/package/skipper-gridfs):
 
-- Bug fix in function `adapter.rm()` that causes callback to be called twice.
-  Detais about it you find [here](https://github.com/willhuang85/skipper-gridfs/pull/44).
+GridFS adapter for receiving [upstreams](https://github.com/balderdashy/skipper#what-are-upstreams). Particularly useful for handling streaming multipart file uploads from the [Skipper](https://github.com/balderdashy/skipper) body parser.
+
+This is a fork from [skipper-gridfs](https://www.npmjs.com/package/skipper-gridfs). Below are the diferences from base repository:
 
 - Added support to `maxBytes` option, using similar logic from `skipper-disk`. Behavior:
   * An error is thrown when upload stream exceeds bytes defined in `maxBytes` parameter.
@@ -15,23 +17,14 @@ This is a fork package from skipper-gridfs. Below are the diferences from [origi
 
 - Added support to `onProgress` using same logic from `skipper-disk`
 
-- Added support to Node >= 14. 
+- Added support to Node >= 14 & MongoDB Node Driver 3.6.5
 
 - CI using official [skipper-adapter-test](https://github.com/balderdashy/skipper-adapter-tests)
 
+- Bug fix in function `adapter.rm()` that causes callback to be called twice.
+  Detais about it you find [here](https://github.com/willhuang85/skipper-gridfs/pull/44).
+
 All the credits about the original package belongs to @willhuang85 and the staff. Great job guys!
-
-========================================
-
-
-# [<img title="skipper-gridfs - GridFS filesystem adapter for Skipper" src="http://i.imgur.com/P6gptnI.png" width="200px" alt="skipper emblem - face of a ship's captain"/>](https://github.com/willhuang85/skipper-gridfs) GridFS Filesystem Adapter
-
-[![npm version](https://badge.fury.io/js/%40dmedina2015%2Fskipper-gridfs.svg)](https://badge.fury.io/js/%40dmedina2015%2Fskipper-gridfs) &nbsp; 
-[![Build Status](https://travis-ci.com/dmedina2015/skipper-gridfs.svg?branch=master)](https://travis-ci.com/dmedina2015/skipper-gridfs)
-&nbsp;
-
-
-GridFS adapter for receiving [upstreams](https://github.com/balderdashy/skipper#what-are-upstreams). Particularly useful for handling streaming multipart file uploads from the [Skipper](https://github.com/balderdashy/skipper) body parser.
 
 Currently only supports Node 6 and up. Node 15 included!
 
@@ -76,7 +69,12 @@ For more detailed usage information and a full list of available options, see th
 | `bucketOptions` | ((object)) | An optional parameter that matches the GridFSBucket options (Check [mongo gridfs bucket options](http://mongodb.github.io/node-mongodb-native/3.1/api/GridFSBucket.html)).                              |
 | `mongoOptions`  | ((object)) | An optional paramter that matches the MongoClient.connect options (Check [mongo client options](http://mongodb.github.io/node-mongodb-native/3.1/api/MongoClient.html#.connect)).                       |
 | `maxBytes`      | ((integer))| Optional. Max total number of bytes permitted for a given upload, calculated by summing the size of all files in the upstream; e.g. if you created an upstream that watches the "avatar" field (`req.file('avatar')`), and a given request sends 15 file fields with the name "avatar", `maxBytes` will check the total number of bytes in all of the 15 files.  If maxBytes is exceeded, the already-written files will be left untouched, but unfinshed file uploads will be garbage-collected, and not-yet-started uploads will be cancelled.  (Note that `maxBytes` is currently experimental) |
-| `onProgress`    | ((function)) | Optional. This function will be called again and again as the upstream pumps chunks into the receiver with a dictionary (plain JavaScript object) representing the current status of the upload, until the upload completes.|
+| `onProgress`    | ((function)) | Optional. This function will be called again and again as the upstream pumps chunks into the receiver with a dictionary (plain JavaScript object) representing the current status of the upload, until the upload completes.
+
+## Error codes
+
+- `E_EXCEEDS_UPLOAD_LIMIT` _(when `maxBytes` is exceeded for upstream)_
+
 ========================================
 
 ## Contributions

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-## [<img title="skipper-gridfs - GridFS filesystem adapter for Skipper" src="http://i.imgur.com/P6gptnI.png" width="200px" alt="skipper emblem - face of a ship's captain"/>](https://github.com/dmedina2015/skipper-gridfs) GridFS Filesystem Adapter
+[<img title="skipper-gridfs - GridFS filesystem adapter for Skipper" src="http://i.imgur.com/P6gptnI.png" width="290px" alt="skipper emblem - face of a ship's captain"/>](https://github.com/dmedina2015/skipper-gridfs)
+## GridFS Filesystem Adapter
 
 [![npm version](https://badge.fury.io/js/%40dmedina2015%2Fskipper-gridfs.svg)](https://badge.fury.io/js/%40dmedina2015%2Fskipper-gridfs) &nbsp; 
 [![Build Status](https://travis-ci.com/dmedina2015/skipper-gridfs.svg?branch=master)](https://travis-ci.com/dmedina2015/skipper-gridfs)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ All the credits about the original package belongs to @willhuang85 and the staff
 # [<img title="skipper-gridfs - GridFS filesystem adapter for Skipper" src="http://i.imgur.com/P6gptnI.png" width="200px" alt="skipper emblem - face of a ship's captain"/>](https://github.com/willhuang85/skipper-gridfs) GridFS Filesystem Adapter
 
 [![npm version](https://badge.fury.io/js/%40dmedina2015%2Fskipper-gridfs.svg)](https://badge.fury.io/js/%40dmedina2015%2Fskipper-gridfs) &nbsp; 
-[![Build Status](https://travis-ci.org/dmedina2015/skipper-gridfs.svg?branch=master)](https://travis-ci.org/dmedina2015/skipper-gridfs)
+[![Build Status](https://travis-ci.com/dmedina2015/skipper-gridfs.svg?branch=master)](https://travis-ci.com/dmedina2015/skipper-gridfs)
 &nbsp;
 
 

--- a/index.js
+++ b/index.js
@@ -181,47 +181,6 @@ module.exports = function SkipperGridFS(globalOptions) {
         return receiver__;
     }
 
-    adapter.info = (fd, cb) => {
-        const errorHandler = (err, client) => {
-            if (client) client.close();
-            if (cb) cb(err);
-        }
-
-        const __transform__ = Transform({ objectMode: true });
-        __transform__._transform = (fileInfo, encoding, callback) => {
-            return callback(null, fileInfo);
-        };
-
-        __transform__.once('done', (client) => {
-            client.close();
-        });
-
-
-        client(options.uri, options.mongoOptions, (err, client) => {
-            if (err) {
-                errorHandler(err, client);
-            }
-
-            const stream = bucket(client.db(), options.bucketOptions).find({ 'metadata.fd' : fd }).transformStream();
-            stream.once('error', (err) => {
-                errorHandler(err, client);
-            });
-
-            stream.once('end', () => {
-                __transform__.emit('done', client);
-            });
-
-            stream.pipe(__transform__);
-        });
-
-        if (cb) {
-            __transform__.pipe(concat((data) => {
-                return cb(null, Array.isArray(data) ? data : [data]);
-            }));
-        } else {
-            return __transform__;
-        }
-    }
     return adapter;
 };
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const path = require('path');
 const mime = require('mime');
 const _ = require('lodash');
 const concat = require('concat-stream');
+const buildProgressStream = require('./standalone/build-progress-stream');
 
 
 
@@ -138,6 +139,15 @@ module.exports = function SkipperGridFS(globalOptions) {
             if (done) done(error);
         });
 
+        // if onProgress handler was provided, bind an event automatically:
+        if (_.isFunction(options.onProgress)) {
+            receiver__.on('progress', options.onProgress);
+        }
+
+        // Track the progress of all file uploads that pass through this receiver
+        // through one or more attached Upstream(s).
+        receiver__._files = [];
+
         receiver__.write = (__newFile, encoding, done) => {
             client(options.uri, options.mongoOptions, (error, client) => {
                 if (error) {
@@ -155,21 +165,42 @@ module.exports = function SkipperGridFS(globalOptions) {
                     },
                     contentType: mime.getType(fd)
                 });
-
+                /* These listeners are not necessary.
+                    outs__ will always fail if there is an error in __newFile
+    
                 __newFile.once('close', () => {
                     receiver__.emit('done', client, done);
                 });
                 __newFile.once('error', (error) => {
                     receiver__.emit('error', error, client, done);
                 });
+                */
                 outs__.once('finish', () => {
                     receiver__.emit('done', client, done);
                 });
-                outs__.once('error', (error) => {
-                    receiver__.emit('error', error, client, done);
-                });
 
-                __newFile.pipe(outs__);
+                outs__.once('E_EXCEEDS_UPLOAD_LIMIT', (error) => {
+                    //Aborts GridFS Upload Stream cleaning all invalid chunks (garbage collector)
+                    outs__.abort(() => {
+                        receiver__.emit('error', error, client, done);
+                    }) 
+                });
+                
+                outs__.once('error', (error) => {
+                    //Aborts GridFS Upload Stream cleaning all invalid chunks (garbage collector)
+                    outs__.abort(() => {
+                        receiver__.emit('error', error, client, done);
+                    })
+                });
+                
+                // Create another stream that simply keeps track of the progress of the file stream and emits `progress` events
+                // on the receiver.
+                const __progress__ = buildProgressStream(options, __newFile, receiver__, outs__, client, done);
+
+
+                __newFile
+                    .pipe(__progress__)
+                    .pipe(outs__);
             });
         }
         return receiver__;

--- a/index.js
+++ b/index.js
@@ -128,20 +128,11 @@ module.exports = function SkipperGridFS(globalOptions) {
     adapter.receive = (opts) => {
         const receiver__ = WritableStream({ objectMode: true });
 
-        receiver__.once('done', (client, done) => {
-            if (client) client.close();
-            if (done) done();
-        });
-
-        receiver__.once('error', (error, client, done) => {
-            if (client) client.close();
-            if (done) done(error);
-        });
-
-        receiver__.write = (__newFile, encoding, done) => {
+        receiver__._write = (__newFile, encoding, done) => {
             client(options.uri, options.mongoOptions, (error, client) => {
                 if (error) {
-                    receiver__.emit('error', error, client, done);
+                    if (client) client.close();
+                    if (done) done(error);
                 }
 
                 const fd = __newFile.fd;
@@ -155,18 +146,22 @@ module.exports = function SkipperGridFS(globalOptions) {
                     },
                     contentType: mime.getType(fd)
                 });
-
-                __newFile.once('close', () => {
-                    receiver__.emit('done', client, done);
-                });
-                __newFile.once('error', (error) => {
-                    receiver__.emit('error', error, client, done);
-                });
+               
                 outs__.once('finish', () => {
-                    receiver__.emit('done', client, done);
+                    receiver__.emit('writefile', __newFile);
+                    if (client) client.close();
+                    done();
                 });
-                outs__.once('error', (error) => {
-                    receiver__.emit('error', error, client, done);
+                outs__.once('error', (err) => {
+                    if (client) client.close();
+                    return done({
+                        incoming: __newFile,
+                        outgoing: outs__,
+                        code: 'E_WRITE',
+                        stack: typeof err === 'object' ? err.stack : new Error(err),
+                        name: typeof err === 'object' ? err.name : err,
+                        message: typeof err === 'object' ? err.message : err
+                    });
                 });
 
                 __newFile.pipe(outs__);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dmedina2015/skipper-gridfs",
-  "version": "1.0.5",
-  "description": "A skipper adapter to allow uploading files to MongoDB's GridFS. Fork made by Daniel Medina.",
+  "version": "1.1.0",
+  "description": "Alternative skipper adapter to allow uploading files to MongoDB's GridFS. Fork made by Daniel Medina.",
   "main": "index.js",
   "scripts": {
     "test": "node -e \"require('skipper-adapter-tests')({module: require('./'), uri: process.env.URI});\""
@@ -17,7 +17,7 @@
     "mongodb",
     "upload"
   ],
-  "author": "",
+  "author": "Daniel Medina",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/dmedina2015/skipper-gridfs/issues"

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   },
   "homepage": "https://github.com/willhuang85/skipper-gridfs",
   "devDependencies": {
-    "skipper-adapter-tests": "github:willhuang85/skipper-adapter-tests#master"
+    "skipper-adapter-tests": "^2.0.0"
   },
   "dependencies": {
     "concat-stream": "^1.6.2",
     "lodash": "^4.17.11",
     "mime": "^2.3.1",
-    "mongodb": "^3.1.8"
+    "mongodb": "^3.6.5"
   }
 }

--- a/standalone/build-progress-stream.js
+++ b/standalone/build-progress-stream.js
@@ -1,0 +1,139 @@
+/**
+* Module dependencies
+*/
+
+var _ = require('@sailshq/lodash');
+var TransformStream = require('stream').Transform;
+
+
+
+/**
+* [exports description]
+* @param  {[type]} options    [description]
+* @param  {[type]} __newFile  [description]
+* @param  {[type]} receiver__ [description]
+* @param  {[type]} outs__     [description]
+* @return {[type]}            [description]
+*/
+module.exports = function buildProgressStream (options, __newFile, receiver__, outs__) {
+    options = options || {};
+    var log = options.log || function noOpLog(){};
+ 
+    // Generate a progress stream and unique id for this file
+    // then pipe the bytes down to the outs___ stream
+    // We will pipe the incoming file stream to this, which will
+    var localID = _.uniqueId();
+    var guessedTotal = 0;
+    var writtenSoFar = 0;
+    var __progress__ = new TransformStream();
+    __progress__._transform = function(chunk, enctype, next) {
+
+        // Update the guessedTotal to make % estimate
+        // more accurate:
+        guessedTotal += chunk.length;
+        writtenSoFar += chunk.length;
+
+        // Do the actual "writing", which in our case will pipe
+        // the bytes to the outs___ stream that writes to GridFS
+        this.push(chunk);
+
+        // Emit an event that will calculate our total upload
+        // progress and determine whether we're within quota
+        this.emit('progress', {
+            id: localID,
+            fd: __newFile.fd,
+            skipperFd: (__newFile.skipperFd || (_.isString(__newFile.fd) ? __newFile.fd : undefined)),
+            name: __newFile.name,
+            written: writtenSoFar,
+            total: guessedTotal,
+            percent: (writtenSoFar / guessedTotal) * 100 | 0
+        });
+        next();
+    };
+ 
+    // This event is fired when a single file stream emits a progress event.
+    // Each time we receive a file, we must recalculate the TOTAL progress
+    // for the aggregate file upload.
+    //
+    // events emitted look like:
+    /*
+    {
+        percentage: 9.05,
+        transferred: 949624,
+        length: 10485760,
+        remaining: 9536136,
+        eta: 10,
+        runtime: 0,
+        delta: 295396,
+        speed: 949624
+    }
+    */
+    __progress__.on('progress', function singleFileProgress(milestone) {
+        // Lookup or create new object to track file progress
+        var currentFileProgress = _.find(receiver__._files, {
+            id: localID
+        });
+        if (currentFileProgress) {
+            currentFileProgress.written = milestone.written;
+            currentFileProgress.total = milestone.total;
+            currentFileProgress.percent = milestone.percent;
+            currentFileProgress.stream = __newFile;
+        } else {
+        currentFileProgress = {
+            id: localID,
+            fd: __newFile.fd,
+            skipperFd: (__newFile.skipperFd || (_.isString(__newFile.fd) ? __newFile.fd : undefined)),
+            name: __newFile.filename,
+            written: milestone.written,
+            total: milestone.total,
+            percent: milestone.percent,
+            stream: __newFile
+        };
+        receiver__._files.push(currentFileProgress);
+        }
+        ////////////////////////////////////////////////////////////////
+ 
+ 
+        // Recalculate `totalBytesWritten` so far for this receiver instance
+        // (across ALL OF ITS FILES)
+        // using the sum of all bytes written to each file in `receiver__._files`
+        var totalBytesWritten = _.reduce(receiver__._files, function(memo, status) {
+        memo += status.written;
+        return memo;
+        }, 0);
+ 
+        log(currentFileProgress.percent, '::', currentFileProgress.written, '/', currentFileProgress.total, '       (file #' + currentFileProgress.id + '   :: ' + /*'update#'+counter*/ '' + ')'); //receiver__._files.length+' files)');
+ 
+        // Emit an event on the receiver.  Someone using Skipper may listen for this to show
+        // a progress bar, for example.
+        receiver__.emit('progress', currentFileProgress);
+ 
+        // and then enforce its `maxBytes`.
+        if (options.maxBytes && totalBytesWritten >= options.maxBytes) {
+    
+            var err = new Error();
+            err.code = 'E_EXCEEDS_UPLOAD_LIMIT';
+            err.name = 'Upload Error';
+            err.maxBytes = options.maxBytes;
+            err.written = totalBytesWritten;
+            err.message = 'Upload limit of ' + err.maxBytes + ' bytes exceeded (' + err.written + ' bytes written)';
+        
+            // Stop listening for progress events
+            __progress__.removeAllListeners('progress');
+            // Unpipe the progress stream, which feeds the GridFS stream, so we don't keep dumping to GridFS
+            process.nextTick(function() {
+                __progress__.unpipe();
+            });
+            
+            // In skipper-disk, this is the point where Garbage Collecting is done.
+            // In skipper-gridfs, the job is done inside the outs__ error listeners using GridFSBucketWriteStream.abort() (see index.js)
+            
+            outs__.emit('E_EXCEEDS_UPLOAD_LIMIT',err);
+            
+        
+            return;
+        }
+    });
+    
+    return __progress__;
+};


### PR DESCRIPTION
Upgraded version to 1.1.0. Major changes:
- Support for `maxBytes`
- Support for `onProgress`
- Support for Node >= 14 (changes in adapter.receive())
- Updated MongoDB Node Driver
- Using official `skipper-adapter-test` for testing
- CI using TravisCI
- Removed adapter.info() function previously created in order to maintain compliance with other skipper adapters.
 